### PR TITLE
Update maven-parent-pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <artifactId>maven-parent-pom</artifactId>
     <groupId>org.exoplatform</groupId>
-    <version>23-SNAPSHOT</version>
+    <version>23-M03</version>
     <relativePath />
   </parent>
   <groupId>org.exoplatform.addons</groupId>


### PR DESCRIPTION
Before this fix, the snapshot version was used to try to release maven-parent-pom and addon-parent-pom in one action.
But it is not possible, so this commit revert the snapshot modification and back to 23-M03 version, and release in 2 steps